### PR TITLE
feat(runtime): per-test outcomes and optional pytest-cov integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Per-test outcome capture: every `pytest` invocation now produces a `cases[]`
+  array on the final report when `pytest-json-report` is installed. Each entry
+  records the `nodeid`, outcome, duration in milliseconds, source file, and the
+  failure message when applicable.
+- Optional coverage capture: when `pytest-cov` is installed the report and
+  trace include a `coverage` block with `overall_percent` and a per-file
+  breakdown. The plugin is optional; absence is handled gracefully.
+- New trace events: `test_case_result` (one per test case) and
+  `coverage_summary` (one per run when coverage is available).
+- CLI: `report --cases` prints just the per-test results, `report --coverage`
+  prints just the coverage block.
+- UI: the Report Panel now renders a per-test case list with color-coded
+  outcomes plus a coverage bar and per-file coverage rows when available.
+
 ## [0.1.0] - 2026-03-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,9 +67,22 @@ Other commands:
 ```bash
 npm run cli -- cancel --run <run-id>
 npm run cli -- report --run <run-id>
+npm run cli -- report --run <run-id> --cases
+npm run cli -- report --run <run-id> --coverage
 npm run cli -- trace --run <run-id>
 npm run cli -- rewind --run <run-id> [--checkpoint <user-message-uuid>]
 ```
+
+To enable richer test telemetry, install the optional Python plugins on your
+local environment:
+
+```bash
+pip install pytest-json-report   # populates report.test_run.cases
+pip install pytest-cov           # populates report.test_run.coverage
+```
+
+Both are optional. When absent, runs still complete normally; the corresponding
+sections are simply empty.
 
 If `npm run cli -- ...` does not forward flags correctly in your shell, use the direct form instead:
 
@@ -108,6 +121,8 @@ In-repo release history is tracked in `CHANGELOG.md`.
 - Claude Agent SDK integration with streaming events, structured output, checkpoint capture, and subagent definitions
 - Deterministic fake-agent path for unit, integration, and CLI smoke tests
 - Local `pytest` execution with stdout/stderr capture, timeout classification, cancellation polling, and one repair round
+- Per-test outcome capture (`cases[]` on the report; `test_case_result` trace events) when `pytest-json-report` is installed
+- Optional line coverage capture (`coverage` block on the report; `coverage_summary` trace event; UI coverage bar) when `pytest-cov` is installed
 - Live-run cancellation propagation through the run-level abort controller, including persisted cancel requests observed across processes
 - Flat-file persistence under `.safetest-forge/` for runs, traces, reports, checkpoints, and fake rewind snapshots
 - React UI with 2-column layout, color-coded trace badges, phase progress bar, click-to-copy run ID, stat grid report panel, and REST + SSE wiring

--- a/docs/tech_spec.md
+++ b/docs/tech_spec.md
@@ -1,5 +1,26 @@
 # Technical Spec
 
+## 2026-05-11
+
+- Extended `TestRunSummary` with `cases: TestCaseResult[]` and an optional
+  `coverage: CoverageSummary`. Older reports without the field are tolerated
+  because the runtime always emits an empty array.
+- The Python runtime adapter probes once per process for the optional
+  `pytest-json-report` and `pytest-cov` plugins via a short `python -c "import …"`
+  subprocess. The result is cached. `runPytest` adds the matching CLI flags
+  only when the relevant plugin is present, writes both artifacts to a
+  per-invocation temp directory, parses them, and deletes the directory before
+  returning.
+- Coverage scope is derived from the analyzer's detected `packageRoots`,
+  converted to repo-relative POSIX paths, and passed as one `--cov=<path>` flag
+  per root. If no roots are detected the runtime falls back to `--cov=.`.
+- The run service emits two new normalized trace events: one
+  `test_case_result` per case and a single `coverage_summary` when coverage is
+  available, both consumed by the React UI for the new Report Panel sections.
+- `pytest-json-report` and `pytest-cov` are intentionally not added to project
+  dependencies (this is a TypeScript project). Both remain optional Python
+  packages that contributors install in their own environment.
+
 ## 2026-03-09
 
 - Added a repository `LICENSE.md` using standard MIT license text as the initial open-source license document.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,6 +67,8 @@ program
 program
   .command("report")
   .requiredOption("--run <runId>", "Run ID")
+  .option("--coverage", "Print only the coverage section")
+  .option("--cases", "Print only the per-test case results")
   .action(async (options) => {
     const runService = new RunService();
     const report = await runService.getReport(options.run);
@@ -75,6 +77,23 @@ program
       process.exitCode = 1;
       return;
     }
+
+    if (options.coverage) {
+      const coverage = report.test_run.coverage;
+      if (!coverage) {
+        console.error("No coverage data was recorded for this run");
+        process.exitCode = 1;
+        return;
+      }
+      console.log(JSON.stringify(coverage, null, 2));
+      return;
+    }
+
+    if (options.cases) {
+      console.log(JSON.stringify(report.test_run.cases ?? [], null, 2));
+      return;
+    }
+
     console.log(JSON.stringify(report, null, 2));
   });
 

--- a/src/run-service.ts
+++ b/src/run-service.ts
@@ -14,6 +14,7 @@ import type { AgentClient } from "./agent/types.js";
 import {
   buildRunContext,
   classifyFailure,
+  detectPytestPlugins,
   ensureTestRoot,
   runPytest,
   validateRepository
@@ -263,15 +264,16 @@ export class RunService {
     const agent = this.agentFactory(context.agentMode);
     let totalCostUsd = 0;
     let modelUsage: Record<string, unknown> = {};
-    let testRun: TestExecutionResult = {
-      command: "pytest",
-      cwd: context.repoPath,
-      exit_code: null,
-      passed: 0,
-      failed: 0,
-      errors: 0,
-      cancelled: false
-    };
+  let testRun: TestExecutionResult = {
+    command: "pytest",
+    cwd: context.repoPath,
+    exit_code: null,
+    passed: 0,
+    failed: 0,
+    errors: 0,
+    cancelled: false,
+    cases: []
+  };
     let status: RunStatus = "running";
     let failureCode: string | null = null;
     let repairAttempted = false;
@@ -330,7 +332,12 @@ export class RunService {
         return await this.finishRun(record, buildFinalReport(context, status, failureCode, analyzedModules, generatedTests, testRun, repairAttempted, repairRoundsUsed, repairStoppedReason, record));
       }
 
-      testRun = await runPytest(context, generatedTests, sink.isCancelled);
+      const pytestPlugins = detectPytestPlugins();
+      const coverageScope = derivePytestCoverageScope(context.repoPath, validation.analysis);
+      const pytestOptions = { plugins: pytestPlugins, coverageScope };
+
+      testRun = await runPytest(context, generatedTests, sink.isCancelled, pytestOptions);
+      await this.emitTestRunResultEvents(context.runId, testRun);
       if (testRun.cancelled) {
         status = "cancelled";
         failureCode = "cancelled";
@@ -362,7 +369,8 @@ export class RunService {
           modelUsage = mergeModelUsage(modelUsage, repair.modelUsage);
           repairRoundsUsed = 1;
           repairStoppedReason = repair.stoppedReason;
-          testRun = await runPytest(context, generatedTests, sink.isCancelled);
+          testRun = await runPytest(context, generatedTests, sink.isCancelled, pytestOptions);
+          await this.emitTestRunResultEvents(context.runId, testRun);
           if (testRun.exit_code === 0) {
             status = "passed";
           } else if (testRun.cancelled) {
@@ -448,6 +456,36 @@ export class RunService {
     await this.store.appendEvent(event.runId, event);
   }
 
+  private async emitTestRunResultEvents(runId: string, testRun: TestExecutionResult): Promise<void> {
+    for (const testCase of testRun.cases ?? []) {
+      await this.emit({
+        runId,
+        ts: nowIso(),
+        type: "test_case_result",
+        data: {
+          nodeid: testCase.nodeid,
+          outcome: testCase.outcome,
+          duration_ms: testCase.duration_ms,
+          file: testCase.file,
+          message: testCase.message
+        }
+      });
+    }
+
+    if (testRun.coverage) {
+      await this.emit({
+        runId,
+        ts: nowIso(),
+        type: "coverage_summary",
+        data: {
+          source: testRun.coverage.source,
+          overall_percent: testRun.coverage.overall_percent,
+          files: testRun.coverage.files
+        }
+      });
+    }
+  }
+
   private async assertNoActiveRun(): Promise<void> {
     const active = await this.store.getActiveRun();
     if (!active) {
@@ -471,6 +509,18 @@ function clampRepairRounds(value: number): number {
 
 function defaultAgentFactory(mode: "claude" | "fake"): AgentClient {
   return mode === "claude" ? new ClaudeAgentClient() : new FakeAgentClient();
+}
+
+function derivePytestCoverageScope(repoPath: string, analysis: { packageRoots: string[] }): string[] {
+  const scope = new Set<string>();
+  for (const packageRoot of analysis.packageRoots) {
+    const relative = path.relative(repoPath, packageRoot);
+    if (!relative || relative.startsWith("..")) {
+      continue;
+    }
+    scope.add(relative.split(path.sep).join(path.posix.sep));
+  }
+  return Array.from(scope);
 }
 
 function buildFinalReport(

--- a/src/runtime/python.ts
+++ b/src/runtime/python.ts
@@ -1,13 +1,19 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 
 import { DEFAULT_TIMEOUT_MS } from "../config.js";
 import type {
   AnalyzedModule,
+  CoverageFileSummary,
+  CoverageSummary,
   GeneratedTest,
   RepoAnalysis,
   RunContext,
+  TestCaseOutcome,
+  TestCaseResult,
   TestExecutionResult,
   ValidationFailure
 } from "../types.js";
@@ -248,17 +254,131 @@ export async function ensureTestRoot(testRoot: string): Promise<void> {
   await ensureDir(testRoot);
 }
 
+export interface PytestPluginAvailability {
+  jsonReport: boolean;
+  cov: boolean;
+}
+
+let cachedPluginAvailability: PytestPluginAvailability | null = null;
+
+export function detectPytestPlugins(force = false): PytestPluginAvailability {
+  if (!force && cachedPluginAvailability) {
+    return cachedPluginAvailability;
+  }
+
+  const jsonReport = pythonImportAvailable("pytest_jsonreport");
+  const cov = pythonImportAvailable("pytest_cov");
+  cachedPluginAvailability = { jsonReport, cov };
+  return cachedPluginAvailability;
+}
+
+function pythonImportAvailable(moduleName: string): boolean {
+  const candidates = ["python3", "python"];
+  for (const candidate of candidates) {
+    try {
+      const result = spawnSync(candidate, ["-c", `import ${moduleName}`], {
+        stdio: "ignore"
+      });
+      if (result.status === 0) {
+        return true;
+      }
+      if (result.status !== null) {
+        return false;
+      }
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return false;
+}
+
+export interface RunPytestOptions {
+  coverageScope?: string[];
+  reportArtifactsDir?: string;
+  plugins?: PytestPluginAvailability;
+}
+
 export async function runPytest(
   context: RunContext,
   generatedTests: GeneratedTest[],
-  isCancelled: () => Promise<boolean>
+  isCancelled: () => Promise<boolean>,
+  options: RunPytestOptions = {}
 ): Promise<TestExecutionResult> {
   const relativeTests = generatedTests.map((item) => item.path);
-  const args = ["-q", ...relativeTests];
+  const plugins = options.plugins ?? detectPytestPlugins();
+  const artifactsDir =
+    options.reportArtifactsDir ?? path.join(os.tmpdir(), `safetest-forge-${randomUUID()}`);
+  await ensureDir(artifactsDir);
+
+  const jsonReportPath = path.join(artifactsDir, "pytest-report.json");
+  const coverageReportPath = path.join(artifactsDir, "coverage.json");
+  const args: string[] = ["-q", ...relativeTests];
+  if (plugins.jsonReport) {
+    args.push("--json-report", `--json-report-file=${jsonReportPath}`);
+  }
+  if (plugins.cov) {
+    const scope = (options.coverageScope ?? []).filter((entry) => entry.length > 0);
+    for (const scopeEntry of scope.length > 0 ? scope : ["."]) {
+      args.push(`--cov=${scopeEntry}`);
+    }
+    args.push(`--cov-report=json:${coverageReportPath}`);
+  }
+
   const command = `pytest ${args.join(" ")}`;
   const startedAt = Date.now();
 
-  return new Promise<TestExecutionResult>((resolve, reject) => {
+  const execution = await spawnPytest(context, args, isCancelled);
+
+  const combined = `${execution.stdout}\n${execution.stderr}`;
+  const textCounts = parsePytestCounts(combined);
+  let cases: TestCaseResult[] = [];
+  let counts = textCounts;
+  if (plugins.jsonReport) {
+    const parsed = await loadJsonReport(jsonReportPath);
+    if (parsed) {
+      cases = parsed.cases;
+      counts = parsed.counts;
+    }
+  }
+
+  let coverage: CoverageSummary | undefined;
+  if (plugins.cov) {
+    coverage = await loadCoverageReport(coverageReportPath, context.repoPath);
+  }
+
+  await fs.rm(artifactsDir, { recursive: true, force: true }).catch(() => {});
+
+  return {
+    command,
+    cwd: context.repoPath,
+    exit_code: execution.exitCode,
+    passed: counts.passed,
+    failed: counts.failed,
+    errors: counts.errors,
+    stdout: execution.stdout,
+    stderr: execution.stderr,
+    duration_ms: Date.now() - startedAt,
+    timed_out: execution.timedOut,
+    cancelled: execution.cancelled,
+    cases,
+    coverage
+  };
+}
+
+interface PytestSpawnResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  cancelled: boolean;
+}
+
+async function spawnPytest(
+  context: RunContext,
+  args: string[],
+  isCancelled: () => Promise<boolean>
+): Promise<PytestSpawnResult> {
+  return new Promise<PytestSpawnResult>((resolve, reject) => {
     const child = spawn("pytest", args, {
       cwd: context.repoPath,
       env: process.env,
@@ -308,23 +428,150 @@ export async function runPytest(
       settled = true;
       clearTimeout(timeout);
       clearInterval(cancelInterval);
-      const combined = `${stdout}\n${stderr}`;
-      const { passed, failed, errors } = parsePytestCounts(combined);
-      resolve({
-        command,
-        cwd: context.repoPath,
-        exit_code: code,
-        passed,
-        failed,
-        errors,
-        stdout,
-        stderr,
-        duration_ms: Date.now() - startedAt,
-        timed_out: timedOut,
-        cancelled
-      });
+      resolve({ exitCode: code, stdout, stderr, timedOut, cancelled });
     });
   });
+}
+
+interface PytestJsonCounts {
+  passed: number;
+  failed: number;
+  errors: number;
+}
+
+interface PytestJsonOutcome {
+  cases: TestCaseResult[];
+  counts: PytestJsonCounts;
+}
+
+async function loadJsonReport(reportPath: string): Promise<PytestJsonOutcome | null> {
+  if (!(await pathExists(reportPath))) {
+    return null;
+  }
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(reportPath, "utf8");
+  } catch {
+    return null;
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const rawTests: any[] = Array.isArray(parsed?.tests) ? parsed.tests : [];
+  const cases: TestCaseResult[] = rawTests.map((entry) => normalizeJsonTest(entry));
+
+  const summary = parsed?.summary ?? {};
+  const summaryPassed = numberOrZero(summary.passed);
+  const summaryFailed = numberOrZero(summary.failed);
+  const summaryErrors = numberOrZero(summary.error) + numberOrZero(summary.errors);
+
+  const counts: PytestJsonCounts = {
+    passed: summaryPassed || cases.filter((item) => item.outcome === "passed").length,
+    failed: summaryFailed || cases.filter((item) => item.outcome === "failed").length,
+    errors: summaryErrors || cases.filter((item) => item.outcome === "error").length
+  };
+
+  return { cases, counts };
+}
+
+function normalizeJsonTest(entry: any): TestCaseResult {
+  const nodeid = typeof entry?.nodeid === "string" ? entry.nodeid : "";
+  const outcome = normalizeOutcome(entry?.outcome);
+  const setupDuration = numberOrZero(entry?.setup?.duration);
+  const callDuration = numberOrZero(entry?.call?.duration);
+  const teardownDuration = numberOrZero(entry?.teardown?.duration);
+  const durationSeconds = setupDuration + callDuration + teardownDuration;
+
+  const callCrash =
+    typeof entry?.call?.crash?.message === "string" ? entry.call.crash.message : null;
+  const setupCrash =
+    typeof entry?.setup?.crash?.message === "string" ? entry.setup.crash.message : null;
+  const message = callCrash ?? setupCrash;
+
+  const file = nodeid.includes("::") ? nodeid.split("::")[0] ?? null : nodeid || null;
+
+  return {
+    nodeid,
+    outcome,
+    duration_ms: Math.round(durationSeconds * 1000),
+    file,
+    message
+  };
+}
+
+function normalizeOutcome(value: unknown): TestCaseOutcome {
+  if (value === "passed" || value === "failed" || value === "skipped" || value === "error") {
+    return value;
+  }
+  if (value === "xfailed" || value === "xpassed") {
+    return value;
+  }
+  return "error";
+}
+
+async function loadCoverageReport(
+  reportPath: string,
+  repoPath: string
+): Promise<CoverageSummary | undefined> {
+  if (!(await pathExists(reportPath))) {
+    return undefined;
+  }
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(reportPath, "utf8");
+  } catch {
+    return undefined;
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+
+  const filesObject = parsed?.files && typeof parsed.files === "object" ? parsed.files : {};
+  const files: CoverageFileSummary[] = [];
+  for (const [filePath, fileEntry] of Object.entries(filesObject)) {
+    const summary = (fileEntry as any)?.summary ?? {};
+    const linesCovered = numberOrZero(summary.covered_lines);
+    const linesTotal = numberOrZero(summary.num_statements);
+    const percent = roundPercent(numberOrZero(summary.percent_covered));
+    files.push({
+      file: toPosix(path.isAbsolute(filePath) ? path.relative(repoPath, filePath) : filePath),
+      lines_covered: linesCovered,
+      lines_total: linesTotal,
+      percent
+    });
+  }
+
+  files.sort((left, right) => left.file.localeCompare(right.file));
+  const totals = parsed?.totals ?? {};
+  const overallPercent = roundPercent(numberOrZero(totals.percent_covered));
+
+  return {
+    source: "pytest-cov",
+    overall_percent: overallPercent,
+    files
+  };
+}
+
+function roundPercent(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function numberOrZero(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return 0;
 }
 
 function parsePytestCounts(output: string): { passed: number; failed: number; errors: number } {

--- a/src/runtime/python.ts
+++ b/src/runtime/python.ts
@@ -273,7 +273,7 @@ export function detectPytestPlugins(force = false): PytestPluginAvailability {
 }
 
 function pythonImportAvailable(moduleName: string): boolean {
-  const candidates = ["python3", "python"];
+  const candidates = process.platform === "win32" ? ["python", "python3"] : ["python3", "python"];
   for (const candidate of candidates) {
     try {
       const result = spawnSync(candidate, ["-c", `import ${moduleName}`], {
@@ -281,9 +281,6 @@ function pythonImportAvailable(moduleName: string): boolean {
       });
       if (result.status === 0) {
         return true;
-      }
-      if (result.status !== null) {
-        return false;
       }
     } catch {
       // Try the next candidate.

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,37 @@ export interface CostSummary {
   by_model: Record<string, unknown>;
 }
 
+export type TestCaseOutcome =
+  | "passed"
+  | "failed"
+  | "skipped"
+  | "error"
+  | "xfailed"
+  | "xpassed";
+
+export interface TestCaseResult {
+  nodeid: string;
+  outcome: TestCaseOutcome;
+  duration_ms: number;
+  file: string | null;
+  message: string | null;
+}
+
+export interface CoverageFileSummary {
+  file: string;
+  lines_covered: number;
+  lines_total: number;
+  percent: number;
+}
+
+export type CoverageSource = "pytest-cov" | "coverage.py" | "unavailable";
+
+export interface CoverageSummary {
+  source: CoverageSource;
+  overall_percent: number;
+  files: CoverageFileSummary[];
+}
+
 export interface TestRunSummary {
   command: string;
   exit_code: number | null;
@@ -78,6 +109,8 @@ export interface TestRunSummary {
   stderr?: string;
   duration_ms?: number;
   timed_out?: boolean;
+  cases: TestCaseResult[];
+  coverage?: CoverageSummary;
 }
 
 export interface RepairSummary {
@@ -140,6 +173,8 @@ export interface TraceEvent {
     | "file_changed"
     | "checkpoint_created"
     | "rewind_available"
+    | "test_case_result"
+    | "coverage_summary"
     | "run_finished"
     | "run_failed";
   data: Record<string, unknown>;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,13 +6,40 @@ type TraceEvent = {
   data: Record<string, unknown>;
 };
 
+type TestCaseResult = {
+  nodeid: string;
+  outcome: string;
+  duration_ms: number;
+  file: string | null;
+  message: string | null;
+};
+
+type CoverageFileSummary = {
+  file: string;
+  lines_covered: number;
+  lines_total: number;
+  percent: number;
+};
+
+type CoverageSummary = {
+  source: string;
+  overall_percent: number;
+  files: CoverageFileSummary[];
+};
+
 type FinalReport = {
   status: string;
   generated_tests: Array<{ path: string }>;
   blocked_operations: Array<{ tool: string; reason: string }>;
   cost: { total_usd: number };
   repair: { attempted: boolean; rounds_used: number; stopped_reason: string | null };
-  test_run: { passed: number; failed: number; errors: number };
+  test_run: {
+    passed: number;
+    failed: number;
+    errors: number;
+    cases?: TestCaseResult[];
+    coverage?: CoverageSummary | null;
+  };
 };
 
 type AppProps = {
@@ -67,7 +94,17 @@ function IconTerminal(): React.JSX.Element {
 
 /* ─── Trace event categorization ─── */
 
-type TraceBadgeCategory = "run" | "tool" | "text" | "file" | "denied" | "checkpoint" | "agent" | "progress";
+type TraceBadgeCategory =
+  | "run"
+  | "tool"
+  | "text"
+  | "file"
+  | "denied"
+  | "checkpoint"
+  | "agent"
+  | "progress"
+  | "case"
+  | "coverage";
 
 function categorizeEvent(type: string): TraceBadgeCategory {
   switch (type) {
@@ -93,6 +130,10 @@ function categorizeEvent(type: string): TraceBadgeCategory {
     case "subagent_started":
     case "subagent_finished":
       return "agent";
+    case "test_case_result":
+      return "case";
+    case "coverage_summary":
+      return "coverage";
     case "task_progress":
     default:
       return "progress";
@@ -115,6 +156,8 @@ function badgeLabel(type: string): string {
     rewind_available: "rewind",
     subagent_started: "agent",
     subagent_finished: "agent",
+    test_case_result: "case",
+    coverage_summary: "coverage",
     task_progress: "progress"
   };
   return map[type] ?? type;
@@ -432,6 +475,63 @@ export function App({ apiBase = "/api", sessionToken = "" }: AppProps): React.JS
                   <span className="report-detail-label">Cost</span>
                   <span className="report-detail-value">${report.cost.total_usd.toFixed(4)}</span>
                 </div>
+                {report.test_run.coverage ? (
+                  <div className="coverage-section">
+                    <div className="coverage-header">
+                      <span className="coverage-label">Coverage</span>
+                      <span className="coverage-percent">
+                        {report.test_run.coverage.overall_percent.toFixed(1)}%
+                      </span>
+                    </div>
+                    <div className="coverage-bar" aria-hidden="true">
+                      <div
+                        className="coverage-bar-fill"
+                        style={{
+                          width: `${Math.min(
+                            100,
+                            Math.max(0, report.test_run.coverage.overall_percent)
+                          )}%`
+                        }}
+                      />
+                    </div>
+                    {report.test_run.coverage.files.length > 0 && (
+                      <ul className="coverage-list">
+                        {report.test_run.coverage.files.slice(0, 8).map((entry) => (
+                          <li key={entry.file} className="coverage-row">
+                            <span className="coverage-row-file">{entry.file}</span>
+                            <span className="coverage-row-percent">
+                              {entry.percent.toFixed(1)}%
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                ) : null}
+                {report.test_run.cases && report.test_run.cases.length > 0 ? (
+                  <div className="cases-section">
+                    <div className="cases-header">
+                      <span className="cases-label">Test cases</span>
+                      <span className="cases-count">{report.test_run.cases.length}</span>
+                    </div>
+                    <ul className="cases-list">
+                      {report.test_run.cases.map((testCase) => (
+                        <li key={testCase.nodeid} className="case-row">
+                          <span
+                            className={`case-outcome case-outcome--${testCase.outcome}`}
+                            title={testCase.outcome}
+                          >
+                            {testCase.outcome}
+                          </span>
+                          <span className="case-node" title={testCase.nodeid}>
+                            {testCase.nodeid}
+                          </span>
+                          <span className="case-duration">{testCase.duration_ms}ms</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
               </>
             ) : (
               <div className="card-body">
@@ -547,6 +647,21 @@ function formatTracePreview(event: TraceEvent): string {
   }
   if (event.type === "task_progress") {
     return String(event.data.phase ?? event.data.status ?? "progress");
+  }
+  if (event.type === "test_case_result") {
+    const nodeid = String(event.data.nodeid ?? "?");
+    const outcome = String(event.data.outcome ?? "?");
+    const duration =
+      typeof event.data.duration_ms === "number" ? `${event.data.duration_ms}ms` : "";
+    return `${outcome.toUpperCase()} ${nodeid} ${duration}`.trim();
+  }
+  if (event.type === "coverage_summary") {
+    const percent =
+      typeof event.data.overall_percent === "number"
+        ? `${(event.data.overall_percent as number).toFixed(1)}%`
+        : "n/a";
+    const files = Array.isArray(event.data.files) ? event.data.files.length : 0;
+    return `overall ${percent} across ${files} files`;
   }
   return truncate(JSON.stringify(event.data), 80);
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -541,6 +541,8 @@ body {
 .trace-badge--checkpoint { background: var(--trace-checkpoint-bg); color: var(--trace-checkpoint); }
 .trace-badge--agent { background: var(--trace-agent-bg); color: var(--trace-agent); }
 .trace-badge--progress { background: var(--trace-progress-bg); color: var(--trace-progress); }
+.trace-badge--case { background: var(--status-passed-bg); color: var(--status-passed); }
+.trace-badge--coverage { background: var(--trace-file-bg); color: var(--trace-file); }
 
 .trace-preview {
   font-size: 13px;
@@ -743,6 +745,160 @@ body {
   text-align: center;
   color: var(--text-tertiary);
   font-size: 13px;
+}
+
+/* ─── Coverage Section ─── */
+
+.coverage-section {
+  border-top: 1px solid var(--border-subtle);
+  padding: 12px 16px 14px;
+}
+
+.coverage-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.coverage-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.coverage-percent {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.coverage-bar {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--border-subtle);
+  overflow: hidden;
+  margin-bottom: 10px;
+}
+
+.coverage-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #059669, #10b981);
+  transition: width 200ms ease;
+}
+
+.coverage-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.coverage-row {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+  gap: 8px;
+}
+
+.coverage-row-file {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.coverage-row-percent {
+  color: var(--text-primary);
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+/* ─── Test Cases Section ─── */
+
+.cases-section {
+  border-top: 1px solid var(--border-subtle);
+  padding: 12px 16px 14px;
+}
+
+.cases-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.cases-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cases-count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.cases-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.case-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.case-outcome {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.case-outcome--passed { background: var(--status-passed-bg); color: var(--status-passed); }
+.case-outcome--failed { background: var(--danger-bg); color: var(--danger); }
+.case-outcome--error { background: var(--danger-bg); color: var(--danger); }
+.case-outcome--skipped { background: var(--trace-progress-bg); color: var(--trace-progress); }
+.case-outcome--xfailed { background: var(--trace-checkpoint-bg); color: var(--trace-checkpoint); }
+.case-outcome--xpassed { background: var(--trace-checkpoint-bg); color: var(--trace-checkpoint); }
+
+.case-node {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+.case-duration {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  font-size: 10px;
 }
 
 /* ─── Phase Progress ─── */

--- a/tests/integration/run-service.test.ts
+++ b/tests/integration/run-service.test.ts
@@ -123,6 +123,31 @@ describe("RunService integration", () => {
     expect(report.failure_code).toBe("cancelled");
   });
 
+  it("captures per-test cases in the final report and trace", async () => {
+    const runService = new RunService();
+    const started = await runService.startRun({
+      repoPath: path.resolve("tests/fixtures/simple-package"),
+      agentMode: "fake"
+    });
+    const report = await started.completion;
+    expect(report.status).toBe("passed");
+    expect(report.test_run.cases.length).toBeGreaterThan(0);
+    expect(
+      report.test_run.cases.every((testCase) => typeof testCase.nodeid === "string" && testCase.nodeid.length > 0)
+    ).toBe(true);
+    expect(
+      report.test_run.cases.every((testCase) => testCase.outcome === "passed")
+    ).toBe(true);
+    expect(
+      report.test_run.cases.every((testCase) => typeof testCase.duration_ms === "number")
+    ).toBe(true);
+
+    const events = await runService.getTrace(started.runId);
+    const caseEvents = events.filter((event) => event.type === "test_case_result");
+    expect(caseEvents.length).toBe(report.test_run.cases.length);
+    expect(caseEvents[0]?.data.outcome).toBe("passed");
+  });
+
   it("rewinds generated fake-agent files", async () => {
     const runService = new RunService();
     const repoPath = path.resolve("tests/fixtures/simple-package");

--- a/tests/ui/app.test.tsx
+++ b/tests/ui/app.test.tsx
@@ -1,19 +1,24 @@
 // @vitest-environment jsdom
 
-import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import React, { act } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { App } from "../../src/ui/App.js";
 
+function installFetchMock(handler: (input: RequestInfo | URL) => Promise<any>): void {
+  (globalThis as any).fetch = vi.fn(async (input: RequestInfo | URL) => handler(input));
+}
+
+function installEventSourceStub(): void {
+  (globalThis as any).EventSource = class {
+    close(): void {}
+  };
+}
+
 describe("App", () => {
   it("renders the major panels", () => {
-    (globalThis as any).fetch = vi.fn(async () => ({
-      ok: false,
-      json: async () => ({ error: "ignored" })
-    }));
-    (globalThis as any).EventSource = class {
-      close(): void {}
-    };
+    installFetchMock(async () => ({ ok: false, json: async () => ({ error: "ignored" }) }));
+    installEventSourceStub();
     render(<App apiBase="/api" sessionToken="token" />);
     expect(screen.getByText("Run Panel")).toBeTruthy();
     expect(screen.getByText("Trace Panel")).toBeTruthy();
@@ -25,16 +30,78 @@ describe("App", () => {
   });
 
   it("toggles trace mode", () => {
-    (globalThis as any).fetch = vi.fn(async () => ({
-      ok: false,
-      json: async () => ({ error: "ignored" })
-    }));
-    (globalThis as any).EventSource = class {
-      close(): void {}
-    };
+    installFetchMock(async () => ({ ok: false, json: async () => ({ error: "ignored" }) }));
+    installEventSourceStub();
     render(<App apiBase="/api" sessionToken="token" />);
     const toggle = screen.getByRole("button", { name: "Show all" });
     fireEvent.click(toggle);
     expect(screen.getByRole("button", { name: "Compact" })).toBeTruthy();
+  });
+
+  it("renders test cases and coverage when present in the report", async () => {
+    const report = {
+      status: "passed",
+      generated_tests: [{ path: "tests/test_calculator.py" }],
+      blocked_operations: [],
+      cost: { total_usd: 0 },
+      repair: { attempted: false, rounds_used: 0, stopped_reason: null },
+      test_run: {
+        passed: 1,
+        failed: 1,
+        errors: 0,
+        cases: [
+          {
+            nodeid: "tests/test_calculator.py::test_add",
+            outcome: "passed",
+            duration_ms: 3,
+            file: "tests/test_calculator.py",
+            message: null
+          },
+          {
+            nodeid: "tests/test_calculator.py::test_divide",
+            outcome: "failed",
+            duration_ms: 5,
+            file: "tests/test_calculator.py",
+            message: "AssertionError"
+          }
+        ],
+        coverage: {
+          source: "pytest-cov",
+          overall_percent: 87.5,
+          files: [
+            { file: "src/calculator.py", lines_covered: 7, lines_total: 8, percent: 87.5 }
+          ]
+        }
+      }
+    };
+
+    installFetchMock(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/runs")) {
+        return { ok: true, json: async () => ({ runId: "run-123" }) };
+      }
+      if (url.includes("/report")) {
+        return { ok: true, json: async () => report };
+      }
+      return { ok: false, json: async () => ({ error: "ignored" }) };
+    });
+    installEventSourceStub();
+
+    render(<App apiBase="/api" sessionToken="token" />);
+    fireEvent.change(screen.getByLabelText("Repository path"), {
+      target: { value: "/repo" }
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Start run/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Test cases")).toBeTruthy();
+    });
+    expect(screen.getByText("Coverage")).toBeTruthy();
+    expect(screen.getAllByText("87.5%").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("tests/test_calculator.py::test_add")).toBeTruthy();
+    expect(screen.getByText("tests/test_calculator.py::test_divide")).toBeTruthy();
+    expect(screen.getByText("src/calculator.py")).toBeTruthy();
   });
 });

--- a/tests/unit/runtime.test.ts
+++ b/tests/unit/runtime.test.ts
@@ -1,10 +1,15 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 import {
   buildAllowedWriteRoots,
+  detectPytestPlugins,
   resolveGeneratedTestPath,
+  runPytest,
   validateRepository
 } from "../../src/runtime/python.js";
+import type { RunContext } from "../../src/types.js";
 
 describe("runtime detection", () => {
   it("detects simple repositories and prefers top-level tests", async () => {
@@ -31,5 +36,102 @@ describe("runtime detection", () => {
   it("advertises only test write roots", () => {
     const repoPath = path.resolve("tests/fixtures/simple-package");
     expect(buildAllowedWriteRoots(repoPath)).toEqual([path.join(repoPath, "tests")]);
+  });
+});
+
+describe("pytest plugin integration", () => {
+  it("populates per-test cases and counts when pytest-json-report is available", async () => {
+    const plugins = detectPytestPlugins(true);
+    if (!plugins.jsonReport) {
+      console.warn("Skipping json-report runtime assertion: plugin not installed");
+      return;
+    }
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "safetest-forge-rt-"));
+    try {
+      const testPath = path.join(tmpDir, "test_demo.py");
+      await fs.writeFile(
+        testPath,
+        [
+          "def test_one():",
+          "    assert 1 + 1 == 2",
+          "",
+          "def test_two():",
+          "    assert 2 + 2 == 4",
+          "",
+          "def test_three():",
+          "    assert 1 + 1 == 3",
+          ""
+        ].join("\n"),
+        "utf8"
+      );
+
+      const context: RunContext = {
+        runId: "runtime-test",
+        repoPath: tmpDir,
+        workspacePath: tmpDir,
+        startedAt: new Date().toISOString(),
+        maxRepairRounds: 0,
+        allowedWriteRoots: [tmpDir],
+        timeoutMs: 30_000,
+        agentMode: "fake"
+      };
+
+      const result = await runPytest(
+        context,
+        [{ path: "test_demo.py", source_targets: [] }],
+        async () => false,
+        { plugins }
+      );
+
+      expect(result.cases.length).toBe(3);
+      const outcomes = result.cases.map((entry) => entry.outcome).sort();
+      expect(outcomes).toEqual(["failed", "passed", "passed"]);
+      expect(result.passed).toBe(2);
+      expect(result.failed).toBe(1);
+      for (const testCase of result.cases) {
+        expect(testCase.nodeid).toContain("test_demo.py::");
+        expect(testCase.duration_ms).toBeGreaterThanOrEqual(0);
+      }
+      const failed = result.cases.find((entry) => entry.outcome === "failed");
+      expect(failed?.message).toMatch(/assert/i);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns no coverage when pytest-cov is not installed", async () => {
+    const plugins = detectPytestPlugins(true);
+    if (plugins.cov) {
+      console.warn("Skipping graceful-degradation check: pytest-cov is installed");
+      return;
+    }
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "safetest-forge-cov-"));
+    try {
+      await fs.writeFile(path.join(tmpDir, "test_noop.py"), "def test_noop():\n    assert True\n", "utf8");
+
+      const context: RunContext = {
+        runId: "coverage-test",
+        repoPath: tmpDir,
+        workspacePath: tmpDir,
+        startedAt: new Date().toISOString(),
+        maxRepairRounds: 0,
+        allowedWriteRoots: [tmpDir],
+        timeoutMs: 30_000,
+        agentMode: "fake"
+      };
+
+      const result = await runPytest(
+        context,
+        [{ path: "test_noop.py", source_targets: [] }],
+        async () => false,
+        { plugins }
+      );
+
+      expect(result.coverage).toBeUndefined();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **per-test outcome capture** and **optional line coverage** to the pytest execution layer. Both are surfaced in the structured final report, in the live trace stream, and in the React Report Panel. Both Python plugins (`pytest-json-report` and `pytest-cov`) are **optional** — if absent, runs continue to work exactly as before and the new sections are simply omitted.

Implements feature #1 from the project review discussion (per-test outcomes + `pytest-cov`, listed under `docs/spec.md §26` as a V2 extension).

## Motivation

Before this change the final report only carried aggregate `passed / failed / errors` counts and the textual stdout/stderr blob. There was no way for a CLI consumer or the UI to answer "which test cases ran and which failed?" without re-parsing the raw pytest output, and there was no signal on what the generated tests actually exercised. This is the single biggest credibility gap for "did the agent actually test useful behavior?", and it unlocks downstream features (per-run diffs, per-file insights, smarter repair targeting).

## What changed

### Schema (`src/types.ts`)

- New types: `TestCaseOutcome`, `TestCaseResult`, `CoverageFileSummary`, `CoverageSource`, `CoverageSummary`.
- `TestRunSummary` gains a required `cases: TestCaseResult[]` (always present, empty when no plugin) and an optional `coverage` block.
- `TraceEvent.type` gains two normalized event types: `test_case_result` and `coverage_summary`.

### Runtime (`src/runtime/python.ts`)

- Module-level `detectPytestPlugins()` probes for `pytest_jsonreport` and `pytest_cov` via a short `python -c "import …"` subprocess. Result is cached per process; tests can pass `force=true`.
- `runPytest()` now accepts an optional `RunPytestOptions { plugins, coverageScope, reportArtifactsDir }`. It writes the json-report and coverage-report into a per-invocation OS temp directory and deletes it after parsing.
- JSON-report parsing normalizes pytest's per-test entries into typed `TestCaseResult`s, including:
  - `nodeid`, normalized `outcome`, `duration_ms` (setup + call + teardown in ms), `file` derived from `nodeid`, and `message` taken from `call.crash.message` or `setup.crash.message`.
  - Falls back gracefully to the existing stdout-regex counts if the file is missing or malformed.
- Coverage parsing reads `coverage.json`, converts absolute file paths to repo-relative POSIX paths, and reports `overall_percent` plus a sorted per-file list.

### Run service (`src/run-service.ts`)

- Derives a `coverageScope: string[]` from `validation.analysis.packageRoots` (relative to `repoPath`, POSIX). One `--cov=<path>` flag is added per detected root; `--cov=.` is the fallback.
- Both pytest invocations (initial + repair rerun) reuse the same `RunPytestOptions` so cases / coverage stay consistent across rounds.
- New `emitTestRunResultEvents()` helper emits one `test_case_result` event per case and one `coverage_summary` event when coverage is available.

### CLI (`src/cli.ts`)

- `safetest-forge report --run <id> --cases` prints just `report.test_run.cases`.
- `safetest-forge report --run <id> --coverage` prints just `report.test_run.coverage`, or exits non-zero with a clear message when coverage is not available.

### UI (`src/ui/App.tsx`, `src/ui/styles.css`)

- Report Panel gains two new sections (rendered only when data is present):
  - **Coverage** — overall percent, animated coverage bar, top-8 per-file rows.
  - **Test cases** — color-coded outcome chip per row (`passed` / `failed` / `error` / `skipped` / `xfailed` / `xpassed`), nodeid, duration.
- Trace stream gets two new badge categories — `case` and `coverage` — with appropriate previews.

### Docs

- `CHANGELOG.md` — new `Unreleased` section.
- `README.md` — current capabilities, new CLI flags, optional plugin install instructions.
- `docs/tech_spec.md` — 2026-05-11 entry covering the runtime probe, scope derivation, schema additions, and the rationale for keeping the plugins optional.

## Backward compatibility

- The `cases` field is **always present** (empty array when no plugin), so existing code that does `report.test_run.cases.length` won't crash. The `coverage` field is optional and `undefined` when no plugin.
- Existing trace consumers that switch on `event.type` will simply ignore the two new event types.
- No new project dependencies. The two Python plugins remain optional contributor-environment installs.

## Test plan

- Unit (`tests/unit/runtime.test.ts`): runs `pytest` against a temp directory with three test functions and asserts `cases.length === 3`, that outcomes sort to `["failed", "passed", "passed"]`, that durations are non-negative, and that the failing case carries an assertion message. A second unit test asserts coverage stays `undefined` when `pytest-cov` is not installed.
- Integration (`tests/integration/run-service.test.ts`): runs the full `RunService` end-to-end against the `simple-package` fixture in fake-agent mode, asserts the report carries per-case results and that the trace contains a matching number of `test_case_result` events.
- UI (`tests/ui/app.test.tsx`): renders the App with a mocked report containing cases and coverage; asserts both sections render and outcome chips appear.

```bash
npm test
```

Local result: **26 / 26 tests pass** (4 new). `npm run build` is also green.

## Risks / known gaps

- Coverage is only emitted when `pytest-cov` is installed. The graceful-degradation path is exercised by tests; the present-and-installed path was exercised manually against `pytest-json-report` (the runtime probe + parse round-trip), but the coverage parse path itself relies on standard `coverage.py` JSON shape (`files.<path>.summary.{covered_lines,num_statements,percent_covered}`) and is unit-tested only structurally for the absent case in this PR. A follow-up that installs `pytest-cov` in CI would close that gap.
- Pytest may produce a JSON report even on cancellation/timeout. The current code parses what it finds and otherwise falls back to the textual counts; cases captured before cancellation are preserved.

## Follow-ups (out of scope for this PR)

- Use `cases[]` as input to the failure-triage subagent to make targeted repair decisions per case.
- Run-to-run diff: with `cases` + content-hashed generated files, `safetest-forge diff --base <id> --head <id>` becomes a small additive feature.
- File-level diff preview in the UI Files Panel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c65099b5-9d7d-48f6-b2e3-e68427ed4ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c65099b5-9d7d-48f6-b2e3-e68427ed4ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

